### PR TITLE
Update settings.ini

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -25,7 +25,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = numpy openradar h5py scipy sklearn tensorflow>=2.5.0 tensorflow_hub>=0.12.0 tensorflow_addons>=0.13.0
+requirements = numpy openradar h5py scipy scikit-learn tensorflow>=2.5.0 tensorflow_hub>=0.12.0 tensorflow_addons>=0.13.0
 # Optional. Same format as setuptools console_scripts
 # console_scripts = 
 # Optional. Same format as setuptools dependency-links


### PR DESCRIPTION
Replaced 'sklearn' with 'scikit-learn'

The following error was thrown during installation: 

```
Collecting sklearn (from radicalsdk==0.0.2)
  Downloading sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

```
